### PR TITLE
Add support for directory descent

### DIFF
--- a/preferences/folder.xml
+++ b/preferences/folder.xml
@@ -2,6 +2,12 @@
 
 <interface domain="wallpaper-changer">
 
+<object class="GtkAdjustment" id="AdjustMaxDescent">
+	<property name="lower">0</property>
+	<property name="upper">100</property>
+	<property name="step_increment">1</property>
+</object>
+
 <object class="GtkGrid" id="prefs_page">
 	<property name="row-spacing">12</property>
 	<property name="row-homogeneous">false</property>
@@ -26,6 +32,32 @@
 					<child>
 						<object class="GtkEntry" id="field_wallpaper_path">
 							<property name="hexpand">true</property>
+						</object>
+					</child>
+				</object>
+			</child>
+		</object>
+	</child>
+	<child>
+		<object class="GtkBox">
+			<property name="margin-top">18</property>
+			<property name="margin-start">18</property>
+			<property name="margin-bottom">18</property>
+			<property name="margin-end">18</property>
+
+			<child>
+				<object class="GtkBox">
+					<property name="spacing">12</property>
+					<child>
+						<object class="GtkLabel">
+							<property name="label" translatable="yes">Max Directory Descent</property>
+							<property name="hexpand">true</property>
+							<property name="halign">1</property>
+						</object>
+					</child>
+					<child>
+						<object class="GtkSpinButton" id="field_max_directory_descent">
+							<property name="adjustment">AdjustMaxDescent</property>
 						</object>
 					</child>
 				</object>

--- a/providers/folderProvider.js
+++ b/providers/folderProvider.js
@@ -6,6 +6,7 @@ const Utils = Self.imports.utils;
 const WallpaperProvider = Self.imports.wallpaperProvider;
 
 let WALLPAPER_PATH = '/usr/share/backgrounds/gnome';
+let MAX_DIRECTORY_DESCENT = 0;
 
 class _Provider extends WallpaperProvider.Provider {
 	static get name() { return "Folder"; }
@@ -20,6 +21,7 @@ class _Provider extends WallpaperProvider.Provider {
 	getPreferences() {
 		const prefs = super.getPreferences();
 		this.settings.bind('wallpaper-path', prefs.get_object('field_wallpaper_path'), 'text', Gio.SettingsBindFlags.DEFAULT);
+		this.settings.bind('max-directory-descent', prefs.get_object('field_max_directory_descent'), 'value', Gio.SettingsBindFlags.DEFAULT);
 		return prefs;
 	}
 
@@ -32,6 +34,7 @@ class _Provider extends WallpaperProvider.Provider {
 
 	applySettings() {
 		WALLPAPER_PATH = this.settings.get_string('wallpaper-path');
+		MAX_DIRECTORY_DESCENT = this.settings.get_int('max-directory-descent');
 		Utils.debug('_applySettings', this.constructor.name);
 
 		this.setupWallpaperDir();
@@ -45,7 +48,7 @@ class _Provider extends WallpaperProvider.Provider {
 		this.monitor = null;
 		this.dir = Gio.File.new_for_path(Utils.realPath(WALLPAPER_PATH));
 		if(this.dir.query_exists(null)) {
-			this.wallpapers = Utils.getFolderWallpapers(this.dir);
+			this.wallpapers = Utils.getFolderWallpapers(this.dir, MAX_DIRECTORY_DESCENT);
 			this.monitor = this.dir.monitor_directory(Gio.FileMonitorFlags.NONE, null)
 			this.monitor.connect('changed', () => {this.wallpapersChanged();});
 		}

--- a/schemas/org.gnome.shell.extensions.wallpaper-changer.providers.folder.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.wallpaper-changer.providers.folder.gschema.xml
@@ -8,5 +8,10 @@
       <summary>Path to wallpaper folder</summary>
       <description>The path to the directory containing the wallpapers</description>
     </key>
+    <key name="max-directory-descent" type="i">
+      <default>0</default>
+      <summary>Number of directories level allowed to descend</summary>
+      <description>How many directories down to descent</description>
+    </key>
   </schema>
 </schemalist>

--- a/utils.js
+++ b/utils.js
@@ -85,10 +85,9 @@ function makeDirectory(path) {
 	return dir;
 }
 
-function getFolderWallpapers(dir, max_depth=10, depth=1, files =[]) {
+function getFolderWallpapers(dir, max_depth=0, depth=0, files =[]) {
 	const children = dir.enumerate_children('standard::name,standard::type',
 		Gio.FileQueryInfoFlags.NONE, null);
-
 	let info = [];
 	while((info = children.next_file(null)) != null) {
 		const type = info.get_file_type();
@@ -113,7 +112,6 @@ function getFolderWallpapers(dir, max_depth=10, depth=1, files =[]) {
 
 	return files;
 }
-
 
 function isValidWallpaper(file, type) {
 	const ext = file.substring(file.lastIndexOf('.') + 1).toLowerCase();


### PR DESCRIPTION
Allows the user to configure the max depth of descent into sub-directories desired. 

Default depth is 0 to maintain current behavior.

Setting the directory descent depth to > 0 will enable recursively descending into sub-directories until either there are no more sub directories, or the directory descent depth is met.